### PR TITLE
Add base modules and design system setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,31 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# webapp-base
 
-## Getting Started
+Plantilla base para aplicaciones Next.js con enfoque modular. Incluye estructura para crear modulos aislados y un design system reutilizable.
 
-First, run the development server:
+## Comenzar
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Estructura
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- `src/modules` – Contiene modulos independientes como `inventory` o `sales`.
+- `src/ui` – Componentes base del design system.
+- `src/app` – Rutas y layout principal.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Cada módulo exporta sus hooks, componentes y servicios desde `index.ts` para facilitar su consumo.
 
-## Learn More
+## Dependencias destacadas
 
-To learn more about Next.js, take a look at the following resources:
+- Next.js
+- React
+- Tailwind CSS
+- axios / swr
+- zod y react-hook-form
+- lucide-react y framer-motion
+- date-fns
+- zustand y grapesjs
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Esta plantilla es compatible con despliegues en Vercel, Netlify o entornos SSR.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,19 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "next": "15.3.4",
+    "tailwindcss": "^3.4.1",
+    "clsx": "^2.1.0",
+    "axios": "^1.6.7",
+    "swr": "^2.2.3",
+    "zod": "^3.22.4",
+    "react-hook-form": "^7.51.3",
+    "lucide-react": "^0.291.0",
+    "framer-motion": "^10.16.7",
+    "date-fns": "^3.6.0",
+    "zustand": "^4.4.5",
+    "grapesjs": "^0.21.9",
+    "shadcn-ui": "^0.3.2"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -20,6 +32,8 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,3 @@
+export const theme = {
+  primary: '#3b82f6',
+};

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/modules/inventory/components/ProductList.html.tsx
+++ b/src/modules/inventory/components/ProductList.html.tsx
@@ -1,0 +1,13 @@
+import { Product } from '../types/Product';
+
+export function ProductList({ items }: { items: Product[] }) {
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <li key={item.id} className="border p-2 rounded">
+          {item.name} - ${item.price}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/modules/inventory/components/index.ts
+++ b/src/modules/inventory/components/index.ts
@@ -1,0 +1,1 @@
+export * from './ProductList.html';

--- a/src/modules/inventory/hooks/useInventory.ts
+++ b/src/modules/inventory/hooks/useInventory.ts
@@ -1,0 +1,7 @@
+import useSWR from 'swr';
+import { fetchInventory } from '../services/inventoryApi';
+
+export function useInventory() {
+  const { data, error } = useSWR('inventory', fetchInventory);
+  return { items: data ?? [], isLoading: !error && !data, error };
+}

--- a/src/modules/inventory/index.ts
+++ b/src/modules/inventory/index.ts
@@ -1,0 +1,4 @@
+export * from './types/Product';
+export * from './hooks/useInventory';
+export * from './services/inventoryApi';
+export * from './components';

--- a/src/modules/inventory/services/inventoryApi.ts
+++ b/src/modules/inventory/services/inventoryApi.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+import { Product } from '../types/Product';
+
+export async function fetchInventory(): Promise<Product[]> {
+  const { data } = await axios.get<Product[]>('/api/inventory');
+  return data;
+}

--- a/src/modules/inventory/types/Product.ts
+++ b/src/modules/inventory/types/Product.ts
@@ -1,0 +1,5 @@
+export interface Product {
+  id: number;
+  name: string;
+  price: number;
+}

--- a/src/modules/page-builder/index.ts
+++ b/src/modules/page-builder/index.ts
@@ -1,0 +1,1 @@
+// TODO: implement page-builder module

--- a/src/modules/sales/index.ts
+++ b/src/modules/sales/index.ts
@@ -1,0 +1,1 @@
+// TODO: implement sales module

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,9 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export function Button({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className="px-4 py-2 bg-blue-500 text-white rounded" {...props}>
+      {children}
+    </button>
+  );
+}

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -1,0 +1,5 @@
+import { InputHTMLAttributes } from 'react';
+
+export function Input(props: InputHTMLAttributes<HTMLInputElement>) {
+  return <input className="border p-2 rounded" {...props} />;
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,2 @@
+export * from './Input';
+export * from './Button';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- scaffold modular folders for Inventory, Sales and Page Builder
- create basic design system components
- add Tailwind and other dependencies in package.json
- configure Tailwind and PostCSS
- document project structure in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcdbb1e708326b9732fdbc9f22441